### PR TITLE
Fix installing mesh and profiles

### DIFF
--- a/plugins/Dremel3D20/Dremel3D20.py
+++ b/plugins/Dremel3D20/Dremel3D20.py
@@ -92,19 +92,12 @@ class Dremel3D20(QObject, MeshWriter, Extension):
 
         self._preferences_window = None
 
-        self.this_plugin_path = None
         self.local_meshes_path = None
         self.local_printer_def_path = None
         self.local_materials_path = None
         self.local_quality_path = None
         Logger.log("i", "Dremel 3D20 Plugin setting up")
-        local_plugin_path = os.path.join(Resources.getStoragePath(Resources.Resources), "plugins")
-        self.this_plugin_path=os.path.join(local_plugin_path,"Dremel3D20","Dremel3D20")
-        local_meshes_paths = Resources.getAllPathsForType(Resources.Meshes)
-
-        for path in local_meshes_paths:
-            if os.path.isdir(path):
-                self.local_meshes_path = path
+        self.local_meshes_path = os.path.join(Resources.getStoragePathForType(Resources.Resources), "meshes")
         self.local_printer_def_path = Resources.getStoragePath(Resources.DefinitionContainers)
         self.local_materials_path = os.path.join(Resources.getStoragePath(Resources.Resources), "materials")
         self.local_quality_path = os.path.join(Resources.getStoragePath(Resources.Resources), "quality")
@@ -270,12 +263,10 @@ class Dremel3D20(QObject, MeshWriter, Extension):
                         folder = self.local_materials_path
                     elif info.filename.endswith(".cfg"):
                         folder = self.local_quality_path
-                    # TODO: figure out a way to install the stl file
-                    # currently Cura doesn't have a local "meshes" folder
-                    # and on windows writing to Program Files requires admin
-                    # access
                     elif info.filename.endswith(".stl"):
                         folder = self.local_meshes_path
+                        if not os.path.exists(folder): #Cura doesn't create this by itself. We may have to.
+                            os.mkdir(folder)
 
                     if folder is not None:
                         extracted_path = zip_ref.extract(info.filename, path = folder)

--- a/plugins/Dremel3D20/Dremel3D20.py
+++ b/plugins/Dremel3D20/Dremel3D20.py
@@ -189,12 +189,15 @@ class Dremel3D20(QObject, MeshWriter, Extension):
     def oldVersionInstalled(self):
         cura_dir=os.path.dirname(os.path.realpath(sys.argv[0]))
         dremelDefinitionFile=os.path.join(cura_dir,"resources","definitions","Dremel3D20.def.json")
+        dremelExtruderFile=os.path.join(cura_dir,"resources","definitions","dremel_3d20_extruder_0.def.json")
         oldPluginPath=os.path.join(cura_dir,"resources","plugins","DremelGCodeWriter")
         dremelMaterialFile=os.path.join(cura_dir,"resources","materials","dremel_pla.xml.fdm_material")
         dremelQualityFolder=os.path.join(cura_dir,"resources","quality","dremel_3d20")
         ret = []
         if os.path.isfile(dremelDefinitionFile):
             ret.append(dremelDefinitionFile)
+        if os.path.isfile(dremelExtruderFile):
+            ret.append(dremelExtruderFile)
         if os.path.isfile(dremelMaterialFile):
             ret.append(dremelMaterialFile)
         if os.path.isdir(dremelQualityFolder):
@@ -223,11 +226,14 @@ class Dremel3D20(QObject, MeshWriter, Extension):
     # check to see if the plugin files are all installed
     def isInstalled(self):
         dremel3D20DefFile = os.path.join(self.local_printer_def_path,"Dremel3D20.def.json")
+        dremelExtruderDefFile = os.path.join(self.local_printer_def_path,"dremel_3d20_extruder_0.def.json")
         dremelPLAfile = os.path.join(self.local_materials_path,"dremel_pla.xml.fdm_material")
         dremelQualityDir = os.path.join(self.local_quality_path,"dremel_3d20")
 
         # if some files are missing then return that this plugin as not installed
         if not os.path.isfile(dremel3D20DefFile):
+            return False
+        if not os.path.isfile(dremelExtruderDefFile):
             return False
         if not os.path.isfile(dremelPLAfile):
             return False
@@ -305,6 +311,16 @@ class Dremel3D20(QObject, MeshWriter, Extension):
                 os.remove(dremel3D20DefFile)
                 restartRequired = True
         except: # Installing a new plugin should never crash the application.
+            Logger.logException("d", "An exception occurred in Dremel 3D20 Plugin while uninstalling files")
+
+        # remove the extruder definition file
+        try:
+            dremel3D20ExtruderFile = os.path.join(self.local_printer_def_path,"dremel_3d20_extruder_0.def.json")
+            if os.path.isfile(dremel3D20ExtruderFile):
+                Logger.log("i", "Dremel 3D20 Plugin removing extruder definition from " + dremel3D20ExtruderFile)
+                os.remove(dremel3D20ExtruderFile)
+                restartRequired = True
+        except: # Installing a new plug-in should never crash the application.
             Logger.logException("d", "An exception occurred in Dremel 3D20 Plugin while uninstalling files")
 
         # remove the pla material file

--- a/plugins/Dremel3D20/__init__.py
+++ b/plugins/Dremel3D20/__init__.py
@@ -19,5 +19,6 @@ def getMetaData():
     }
 
 def register(app):
-    return { "mesh_writer": Dremel3D20.Dremel3D20(),
-             "extension": Dremel3D20.Dremel3D20()}
+    plugin = Dremel3D20.Dremel3D20()
+    return { "mesh_writer": plugin,
+             "extension": plugin}

--- a/resources/definitions/Dremel3D20.def.json
+++ b/resources/definitions/Dremel3D20.def.json
@@ -13,7 +13,11 @@
         "has_materials": true,
         "preferred_material": "dremel_pla",
         "exclude_materials": [ "generic_hips", "generic_petg", "generic_abs", "generic_cpa", "generic_nylon", "generic_bam", "generic_pc", "generic_pva", "generic_tpu", "generic_tough", "generic_cpe", "generic_pet"],
-        "preferred_quality": "low"
+        "preferred_quality": "low",
+        "machine_extruder_trains":
+        {
+            "0": "dremel_3d20_extruder_0"
+        }
     },
 
     "overrides": {
@@ -37,7 +41,6 @@
         "machine_gcode_flavor": { "default_value": "Marlin" },
         "machine_depth": { "default_value": 150 },
         "machine_width": { "default_value": 230 },
-        "material_diameter": { "default_value": 1.75 },
         "retraction_speed": {"default_value":25},
         "cool_fan_speed_min": {"default_value": 0},
         "cool_fan_speed_max": {"default_value": 100},

--- a/resources/definitions/dremel_3d20_extruder_0.def.json
+++ b/resources/definitions/dremel_3d20_extruder_0.def.json
@@ -1,0 +1,16 @@
+{
+    "version": 2,
+    "name": "Extruder 1",
+    "inherits": "fdmextruder",
+    "metadata": {
+        "machine": "Dremel3D20",
+        "position": "0"
+    },
+
+    "overrides": {
+        "extruder_nr": { "default_value": 0 },
+        "machine_nozzle_size": { "default_value": 0.4 },
+        "material_diameter": { "default_value": 1.75 }
+    }
+}
+

--- a/tools/make_release.bat
+++ b/tools/make_release.bat
@@ -20,6 +20,7 @@ if EXIST .\Cura-Dremel-3D20.curapackage (del .\Cura-Dremel-3D20.curapackage)
 :: copy the dremel printer definitions, the materials, and the quality files
 ::::::::::::::::::::::::::::::::::
 xcopy ..\resources\definitions\Dremel3D20.def.json %PLUGIN_DIR%
+xcopy ..\resources\definitions\dremel_3d20_extruder_0.def.json %PLUGIN_DIR%
 xcopy ..\resources\materials\dremel_pla.xml.fdm_material %PLUGIN_DIR%
 mkdir %PLUGIN_DIR%\dremel_3d20
 xcopy ..\resources\quality\dremel_3d20 %PLUGIN_DIR%\dremel_3d20 /E
@@ -35,6 +36,7 @@ xcopy ..\resources\quality\dremel_3d20 %PLUGIN_DIR%\dremel_3d20 /E
 :: now delete the files that were copied in Step 2
 ::::::::::::::::::::::::::::::::::
 del /f /s /q %PLUGIN_DIR%\Dremel3D20.def.json
+del /f /s /q %PLUGIN_DIR%\dremel_3d20_extruder_0.def.json
 del /f /s /q %PLUGIN_DIR%\dremel_pla.xml.fdm_material
 del /f /s /q %PLUGIN_DIR%\dremel_3d20
 rmdir %PLUGIN_DIR%\dremel_3d20


### PR DESCRIPTION
I've taken some time to fix the installation of profiles for you on the current Cura master. The profiles were not being loaded because the material diameter must be set in an extruder definition now, or the extruder definition of fdmextruder.def.json would overwrite it to 2.85.

I've also made a fix for installing the mesh. It now just creates a folder 'meshes' in the data resources path and puts the file there.

Another fix included here is to not do all of these things if your plug-in is disabled by the user. That is just a bit neater, I'd say.

This was tested on the current Master branch of Cura, set for beta release in a month and a half. I didn't test on 3.4 but I would expect that it works the same. I've also not tested the release making script tool because that only runs on Windows.