### PR TITLE
Prepare for release of version 0.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 https://github.com/timmehtimmeh/Cura-Dremel-Printer-Plugin/
 
-This is a plugin for [Cura version 4.4 and onward](https://ultimaker.com/en/products/ultimaker-cura-software) that adds the Dremel Ideabuilder 3D20, 3D40<sup>[*FAQ1](#FAQ)</sup>, and 3D45 printer to Cura and enables Cura to export to the proprietary Dremel .g3drem file format.
+This is a plugin for [Cura](https://ultimaker.com/en/products/ultimaker-cura-software) that adds the Dremel Ideabuilder 3D20, 3D40<sup>[*FAQ1](#FAQ)</sup>, and 3D45 printer to Cura and enables Cura to export to the proprietary Dremel .g3drem file format.
 
 # <a name="Table_Of_Contents"></a>Table Of Contents
 - [Introduction](#Introduction)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This plugin is available within the Cura marketplace.  Users are encouraged to u
 
 | Cura Version | Last version of the 3D20 plugin that works with the version of Cura         | Supported Printers |
 |--------------|------------------------------------------------------------------------|-----|
-5.0 | [version 0.8.0](https://github.com/timmehtimmeh/Cura-Dremel-Printer-Plugin/releases/tag/0.8.0) | 3D20, 3D40<sup>[*FAQ1](#FAQ)</sup>, 3D45|
+5.0 through 5.1 | [version 0.8.1](https://github.com/timmehtimmeh/Cura-Dremel-Printer-Plugin/releases/tag/0.8.1) | 3D20, 3D40<sup>[*FAQ1](#FAQ)</sup>, 3D45|
 4.4 through 4.13.1 | [version 0.7.2](https://github.com/timmehtimmeh/Cura-Dremel-Printer-Plugin/releases/tag/0.7.2) | 3D20, 3D40<sup>[*FAQ1](#FAQ)</sup>, 3D45|
 3.5 through 4.3  | [version 0.5.9](https://github.com/timmehtimmeh/Cura-Dremel-3D20-Plugin/releases/tag/0.5.9) | 3D20 |
 3.4 or 3.4.1   | [version 0.4.8](https://github.com/timmehtimmeh/Cura-Dremel-3D20-Plugin/releases/tag/0.4.8) | 3D20 |
@@ -250,7 +250,7 @@ A description of the current understanding of this file format is below:
 
 ---
 # <a name="Contributors"></a>Contributors
-Many thanks to the following users, who have contributed to the plugin in various ways:
+Many thanks to the following users, who have contributed to the plugin:
 * [metalman3797](https://github.com/metalman3797)
 * [Rally037](https://github.com/Rally037)
 * [Ghostkeeper](https://github.com/Ghostkeeper)
@@ -265,6 +265,7 @@ Many thanks to the following users, who have contributed to the plugin in variou
 * Tijs Kooij
 * [takacsa](https://github.com/takacsa)
 * [lenigma1](https://github.com/lenigma1)
+* [Troy McFarland](https://pacificsciencecenter.org/)
 * The rest of the engineering team at [Ultimaker](https://ultimaker.com/)
 
 ---

--- a/plugins/DremelPrinterPlugin/DremelPrinterPlugin.py
+++ b/plugins/DremelPrinterPlugin/DremelPrinterPlugin.py
@@ -64,7 +64,7 @@ class DremelPrinterPlugin(QObject, MeshWriter, Extension):
     ##    2) .\plugin.json
     ##    3) ..\..\resources\package.json
     ######################################################################
-    version = "0.8.0"
+    version = "0.8.1"
 
     ######################################################################
     ##  Dictionary that defines how characters are escaped when embedded in

--- a/plugins/DremelPrinterPlugin/plugin.json
+++ b/plugins/DremelPrinterPlugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "Dremel Printer Plugin",
     "author": "Tim Schoenmackers",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "description": "Enables the user to add the Dremel Ideabuilder 3D20, 3D40, and 3D45 printer to Cura and export the proprietary .g3drem files.",
     "supported_sdk_versions": ["8.0.0"],
     "i18n-catalog": "cura"

--- a/resources/definitions/Dremel3D20.def.json
+++ b/resources/definitions/Dremel3D20.def.json
@@ -146,7 +146,7 @@
             "verbatim_bvoh_175",
             "zyyx_pro_flex"
         ],
-        "file_formats": "application/x-g3drem",
+        "file_formats": "application/x-g3drem;text/x-gcode",
         "has_machine_quality": true,
         "has_materials": true,
         "machine_extruder_trains": {

--- a/resources/definitions/Dremel3D40.def.json
+++ b/resources/definitions/Dremel3D40.def.json
@@ -147,7 +147,7 @@
             "verbatim_bvoh_175",
             "zyyx_pro_flex"
         ],
-        "file_formats": "application/x-g3drem",
+        "file_formats": "application/x-g3drem;text/x-gcode",
         "has_machine_materials": true,
         "has_machine_quality": true,
         "has_materials": true,

--- a/resources/definitions/Dremel3D45.def.json
+++ b/resources/definitions/Dremel3D45.def.json
@@ -4,7 +4,7 @@
     "metadata": {
         "author": "Tim Schoenmackers",
         "category": "Dremel",
-        "file_formats": "application/x-g3drem",
+        "file_formats": "application/x-g3drem;text/x-gcode",
         "has_machine_materials": true,
         "has_machine_quality": true,
         "has_materials": true,

--- a/resources/package.json
+++ b/resources/package.json
@@ -9,7 +9,7 @@
     "display_name": "Dremel Printer Plugin",
     "package_id": "DremelPrinterPlugin",
     "package_type": "plugin",
-    "package_version": "0.8.0",
+    "package_version": "0.8.1",
     "sdk_version": 8,
     "tags": [
         "Dremel",

--- a/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_0.5kg_fast.inst.cfg
+++ b/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_0.5kg_fast.inst.cfg
@@ -45,5 +45,3 @@ support_top_distance = 0.34
 support_xy_distance_overhang = 0.34
 support_xy_overrides_z = xy_overrides_z
 top_layers = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_0.5kg_high.inst.cfg
+++ b/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_0.5kg_high.inst.cfg
@@ -66,5 +66,3 @@ top_bottom_thickness = 1
 top_layers = 10
 travel_retract_before_outer_wall = True
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_draft.inst.cfg
+++ b/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_draft.inst.cfg
@@ -60,5 +60,3 @@ support_xy_overrides_z = xy_overrides_z
 support_z_distance = 0.4
 top_bottom_pattern = zigzag
 top_layers = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_fast.inst.cfg
+++ b/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_fast.inst.cfg
@@ -48,5 +48,3 @@ support_top_distance = 0.34
 support_xy_distance_overhang = 0.34
 support_xy_overrides_z = xy_overrides_z
 top_layers = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_high.inst.cfg
+++ b/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_high.inst.cfg
@@ -69,5 +69,3 @@ top_bottom_thickness = 1
 top_layers = 10
 travel_retract_before_outer_wall = True
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_low.inst.cfg
+++ b/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_low.inst.cfg
@@ -56,5 +56,3 @@ support_xy_overrides_z = xy_overrides_z
 support_z_distance = 0.4
 top_bottom_pattern = zigzag
 top_layers = 4
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_normal.inst.cfg
+++ b/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_normal.inst.cfg
@@ -63,5 +63,3 @@ top_bottom_pattern = zigzag
 top_bottom_thickness = 1
 top_layers = 10
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D40/Dremel_3D40_dremel_pla_0.5kg_draft.inst.cfg
+++ b/resources/quality/Dremel3D40/Dremel_3D40_dremel_pla_0.5kg_draft.inst.cfg
@@ -59,5 +59,3 @@ top_bottom_thickness = 0.8
 top_bottom_pattern = zigzag
 top_layers = 3
 wall_line_count = 2
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D40/Dremel_3D40_dremel_pla_0.5kg_low.inst.cfg
+++ b/resources/quality/Dremel3D40/Dremel_3D40_dremel_pla_0.5kg_low.inst.cfg
@@ -51,5 +51,3 @@ support_z_distance = 0.1
 top_bottom_thickness = 0.8
 top_layers = 4
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D40/Dremel_3D40_dremel_pla_0.5kg_normal.inst.cfg
+++ b/resources/quality/Dremel3D40/Dremel_3D40_dremel_pla_0.5kg_normal.inst.cfg
@@ -60,5 +60,3 @@ support_z_distance = 0.2
 top_bottom_thickness = 1
 top_layers = 10
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_eco_abs_draft.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_eco_abs_draft.inst.cfg
@@ -57,5 +57,3 @@ top_bottom_pattern = zigzag
 top_layers = 3
 travel_compensate_overlapping_walls_x_enabled = True
 wall_line_count = 4
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_eco_abs_fast.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_eco_abs_fast.inst.cfg
@@ -50,5 +50,3 @@ top_bottom_pattern = zigzag
 top_layers = 3
 travel_compensate_overlapping_walls_x_enabled = True
 wall_line_count = 4
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_eco_abs_high.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_eco_abs_high.inst.cfg
@@ -67,5 +67,3 @@ top_bottom_thickness = 1
 top_layers = 20
 travel_compensate_overlapping_walls_x_enabled = True
 wall_line_count = 4
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_eco_abs_low.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_eco_abs_low.inst.cfg
@@ -57,5 +57,3 @@ top_bottom_pattern = zigzag
 top_layers = 4
 travel_compensate_overlapping_walls_x_enabled = True
 wall_line_count = 4
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_eco_abs_normal.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_eco_abs_normal.inst.cfg
@@ -59,5 +59,3 @@ top_bottom_thickness = 1
 top_layers = 10
 travel_compensate_overlapping_walls_x_enabled = True
 wall_line_count = 4
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_nylon_draft.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_nylon_draft.inst.cfg
@@ -58,5 +58,3 @@ top_bottom_pattern = zigzag
 top_layers = 3
 travel_compensate_overlapping_walls_x_enabled = True
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_nylon_fast.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_nylon_fast.inst.cfg
@@ -52,5 +52,3 @@ top_bottom_pattern = zigzag
 top_layers = 3
 travel_compensate_overlapping_walls_x_enabled = True
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_nylon_high.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_nylon_high.inst.cfg
@@ -69,5 +69,3 @@ top_bottom_thickness = 1
 top_layers = 20
 travel_compensate_overlapping_walls_x_enabled = True
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_nylon_low.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_nylon_low.inst.cfg
@@ -59,5 +59,3 @@ top_bottom_pattern = zigzag
 top_layers = 4
 travel_compensate_overlapping_walls_x_enabled = True
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_nylon_normal.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_nylon_normal.inst.cfg
@@ -61,5 +61,3 @@ top_bottom_thickness = 1
 top_layers = 10
 travel_compensate_overlapping_walls_x_enabled = True
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_petg_draft.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_petg_draft.inst.cfg
@@ -57,5 +57,3 @@ top_bottom_pattern = zigzag
 top_layers = 3
 travel_compensate_overlapping_walls_x_enabled = True
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_petg_fast.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_petg_fast.inst.cfg
@@ -51,5 +51,3 @@ top_bottom_pattern = zigzag
 top_layers = 3
 travel_compensate_overlapping_walls_x_enabled = True
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_petg_high.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_petg_high.inst.cfg
@@ -71,5 +71,3 @@ top_bottom_thickness = 1
 top_layers = 20
 travel_compensate_overlapping_walls_x_enabled = True
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_petg_low.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_petg_low.inst.cfg
@@ -58,5 +58,3 @@ top_bottom_pattern = zigzag
 top_layers = 4
 travel_compensate_overlapping_walls_x_enabled = True
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_petg_normal.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_petg_normal.inst.cfg
@@ -60,5 +60,3 @@ top_bottom_thickness = 1
 top_layers = 10
 travel_compensate_overlapping_walls_x_enabled = True
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_draft.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_draft.inst.cfg
@@ -60,5 +60,3 @@ top_bottom_pattern = zigzag
 top_layers = 3
 travel_compensate_overlapping_walls_x_enabled = True
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_draft_0.5kg.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_draft_0.5kg.inst.cfg
@@ -59,5 +59,3 @@ top_bottom_pattern = zigzag
 top_layers = 3
 travel_compensate_overlapping_walls_x_enabled = True
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_fast.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_fast.inst.cfg
@@ -51,5 +51,3 @@ top_bottom_pattern = zigzag
 top_layers = 3
 travel_compensate_overlapping_walls_x_enabled = True
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_fast_0.5kg.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_fast_0.5kg.inst.cfg
@@ -51,5 +51,3 @@ top_bottom_pattern = zigzag
 top_layers = 3
 travel_compensate_overlapping_walls_x_enabled = True
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_high.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_high.inst.cfg
@@ -69,5 +69,3 @@ top_bottom_thickness = 1
 top_layers = 20
 travel_compensate_overlapping_walls_x_enabled = True
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_high_0.5kg.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_high_0.5kg.inst.cfg
@@ -68,5 +68,3 @@ top_bottom_thickness = 1
 top_layers = 20
 travel_compensate_overlapping_walls_x_enabled = True
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_low.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_low.inst.cfg
@@ -58,5 +58,3 @@ top_bottom_pattern = zigzag
 top_layers = 4
 travel_compensate_overlapping_walls_x_enabled = True
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_low_0.5kg.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_low_0.5kg.inst.cfg
@@ -58,5 +58,3 @@ top_bottom_pattern = zigzag
 top_layers = 4
 travel_compensate_overlapping_walls_x_enabled = True
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_normal.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_normal.inst.cfg
@@ -63,5 +63,3 @@ top_bottom_thickness = 1
 top_layers = 10
 travel_compensate_overlapping_walls_x_enabled = True
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_normal_0.5kg.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_normal_0.5kg.inst.cfg
@@ -62,5 +62,3 @@ top_bottom_thickness = 1
 top_layers = 10
 travel_compensate_overlapping_walls_x_enabled = True
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/dremel_3d20/Dremel_3D20_dremel_pla_draft.inst.cfg
+++ b/resources/quality/dremel_3d20/Dremel_3D20_dremel_pla_draft.inst.cfg
@@ -62,6 +62,4 @@ top_bottom_thickness = 0.8
 top_bottom_pattern = zigzag
 top_layers = 3
 wall_line_count = 2
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25
 

--- a/resources/quality/dremel_3d20/Dremel_3D20_dremel_pla_low.inst.cfg
+++ b/resources/quality/dremel_3d20/Dremel_3D20_dremel_pla_low.inst.cfg
@@ -64,5 +64,3 @@ top_bottom_pattern = zigzag
 top_bottom_thickness = 0.8
 top_layers = 4
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25

--- a/resources/quality/dremel_3d20/Dremel_3D20_dremel_pla_normal.inst.cfg
+++ b/resources/quality/dremel_3d20/Dremel_3D20_dremel_pla_normal.inst.cfg
@@ -58,5 +58,3 @@ support_xy_overrides_z = xy_overrides_z
 support_z_distance = 0.1
 top_layers = 6
 wall_line_count = 3
-wall_overhang_angle = 25
-wall_overhang_speed_factor = 25


### PR DESCRIPTION
Remove `wall_overhang_angle` and `wall_overhang_speed_factor` from quality profiles to remove some artifacts on the calibration cube.  This artifact was especially visible on the 3D calibration cube "X" face.

before:
<img src=https://user-images.githubusercontent.com/19733103/185852491-dc53754c-4904-4f40-8d23-2e1c027b8892.png width="400" />  <img src=https://user-images.githubusercontent.com/19733103/185852555-d44af123-5c04-4307-b902-b5fab957464f.png width="378" />

now:
<img src=https://user-images.githubusercontent.com/19733103/185852695-357cecea-b7dd-4ada-9c38-ccf501f24264.png width="400" /> <img src=https://user-images.githubusercontent.com/19733103/185852673-5bd60123-1967-4ec9-904c-4c69923c6d70.png width="305" />
