### PR TITLE
Exclude M117 commands from being written to gcode file

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Many thanks to the following users, who have contributed to the plugin:
 * [takacsa](https://github.com/takacsa)
 * [lenigma1](https://github.com/lenigma1)
 * [Troy McFarland](https://pacificsciencecenter.org/)
+* [Fishhooks1945](https://github.com/Fishhooks1945)
 * The rest of the engineering team at [Ultimaker](https://ultimaker.com/)
 
 ---

--- a/plugins/DremelPrinterPlugin/DremelPrinterPlugin.py
+++ b/plugins/DremelPrinterPlugin/DremelPrinterPlugin.py
@@ -64,7 +64,7 @@ class DremelPrinterPlugin(QObject, MeshWriter, Extension):
     ##    2) .\plugin.json
     ##    3) ..\..\resources\package.json
     ######################################################################
-    version = "0.8.1"
+    version = "0.8.2"
 
     ######################################################################
     ##  Dictionary that defines how characters are escaped when embedded in
@@ -78,6 +78,9 @@ class DremelPrinterPlugin(QObject, MeshWriter, Extension):
         re.escape("\n"): "\\n",   # Newlines. They break off the comment.
         re.escape("\r"): "\\r"    # Carriage return. Windows users may need this for visualisation in their editors.
     }
+
+    exclude_gcode = ['M117']      # if Cura attempts to write any of the gcodes in this list they will be skipped
+                                  # i.e. the 3D45 doesn't support the M117 gcode
 
     _setting_keyword = ";SETTING_"
 
@@ -727,6 +730,9 @@ class DremelPrinterPlugin(QObject, MeshWriter, Extension):
                     try:
                         if gcode[:len(self._setting_keyword)] == self._setting_keyword:
                              has_settings = True
+                        # exclude unsupported commands here
+                        if bool([ele for ele in self.exclude_gcode if(ele in gcode)]):
+                            continue
                         stream.write(gcode.encode())
                     except:
                         Logger.logException("w", "Dremel Plugin - Error writing gcode to file.")

--- a/plugins/DremelPrinterPlugin/plugin.json
+++ b/plugins/DremelPrinterPlugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "Dremel Printer Plugin",
     "author": "Tim Schoenmackers",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "description": "Enables the user to add the Dremel Ideabuilder 3D20, 3D40, and 3D45 printer to Cura and export the proprietary .g3drem files.",
     "supported_sdk_versions": ["8.0.0"],
     "i18n-catalog": "cura"

--- a/resources/package.json
+++ b/resources/package.json
@@ -9,7 +9,7 @@
     "display_name": "Dremel Printer Plugin",
     "package_id": "DremelPrinterPlugin",
     "package_type": "plugin",
-    "package_version": "0.8.1",
+    "package_version": "0.8.2",
     "sdk_version": 8,
     "tags": [
         "Dremel",


### PR DESCRIPTION
This PR excludes M117 commands from being written to a g3drem file (Issue #94 ).  It also updates the plugin version to 0.8.2, and adds @Fishhooks1945 as a contributor to the plugin