### PR TITLE
Fix #102 - remove all instances of cool_min_speed=0

### DIFF
--- a/plugins/DremelPrinterPlugin/DremelPrinterPlugin.py
+++ b/plugins/DremelPrinterPlugin/DremelPrinterPlugin.py
@@ -64,7 +64,7 @@ class DremelPrinterPlugin(QObject, MeshWriter, Extension):
     ##    2) .\plugin.json
     ##    3) ..\..\resources\package.json
     ######################################################################
-    version = "0.8.1"
+    version = "0.8.2"
 
     ######################################################################
     ##  Dictionary that defines how characters are escaped when embedded in

--- a/plugins/DremelPrinterPlugin/plugin.json
+++ b/plugins/DremelPrinterPlugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "Dremel Printer Plugin",
     "author": "Tim Schoenmackers",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "description": "Enables the user to add the Dremel Ideabuilder 3D20, 3D40, and 3D45 printer to Cura and export the proprietary .g3drem files.",
     "supported_sdk_versions": ["8.0.0"],
     "i18n-catalog": "cura"

--- a/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_0.5kg_fast.inst.cfg
+++ b/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_0.5kg_fast.inst.cfg
@@ -16,7 +16,6 @@ bottom_layers = 3
 cool_fan_enabled = True
 cool_fan_speed = 80
 cool_min_layer_time = 5
-cool_min_speed = 0
 infill_sparse_density = 10
 layer_height = 0.34
 line_width = 0.48

--- a/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_0.5kg_high.inst.cfg
+++ b/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_0.5kg_high.inst.cfg
@@ -17,7 +17,6 @@ cool_fan_enabled = True
 cool_fan_full_at_height = 0.4
 cool_fan_speed = 80
 cool_min_layer_time = 5
-cool_min_speed = 0
 infill_pattern = zigzag
 infill_sparse_density = 20
 ironing_enabled = True

--- a/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_draft.inst.cfg
+++ b/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_draft.inst.cfg
@@ -17,7 +17,6 @@ cool_fan_enabled = True
 cool_fan_full_at_height = 0.6
 cool_fan_speed = 80
 cool_min_layer_time = 5
-cool_min_speed = 0
 default_material_print_temperature = 220
 infill_before_walls = False
 infill_overlap = 12

--- a/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_fast.inst.cfg
+++ b/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_fast.inst.cfg
@@ -16,7 +16,6 @@ bottom_layers = 3
 cool_fan_enabled = True
 cool_fan_speed = 80
 cool_min_layer_time = 5
-cool_min_speed = 0
 default_material_print_temperature = 220
 infill_sparse_density = 10
 layer_height = 0.34

--- a/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_high.inst.cfg
+++ b/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_high.inst.cfg
@@ -17,7 +17,6 @@ cool_fan_enabled = True
 cool_fan_full_at_height = 0.4
 cool_fan_speed = 80
 cool_min_layer_time = 5
-cool_min_speed = 0
 default_material_print_temperature = 220
 infill_pattern = zigzag
 infill_sparse_density = 20

--- a/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_low.inst.cfg
+++ b/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_low.inst.cfg
@@ -16,7 +16,6 @@ bottom_layers = 4
 cool_fan_enabled = True
 cool_fan_speed = 80
 cool_min_layer_time = 5
-cool_min_speed = 0
 default_material_print_temperature = 220
 infill_before_walls = False
 infill_overlap = 12

--- a/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_normal.inst.cfg
+++ b/resources/quality/Dremel3D40/Dremel3D40_dremel_pla_normal.inst.cfg
@@ -17,7 +17,6 @@ cool_fan_enabled = True
 cool_fan_full_at_height = 0.4
 cool_fan_speed = 80
 cool_min_layer_time = 5
-cool_min_speed = 0
 default_material_print_temperature = 220
 infill_before_walls = False
 infill_overlap = 12

--- a/resources/quality/Dremel3D40/Dremel_3D40_dremel_pla_0.5kg_draft.inst.cfg
+++ b/resources/quality/Dremel3D40/Dremel_3D40_dremel_pla_0.5kg_draft.inst.cfg
@@ -16,7 +16,6 @@ bottom_layers = 3
 cool_fan_enabled = True
 cool_fan_speed = 80
 cool_min_layer_time = 5
-cool_min_speed = 0
 infill_angles = [45,-45]
 infill_before_walls = False
 infill_overlap = 18

--- a/resources/quality/Dremel3D40/Dremel_3D40_dremel_pla_0.5kg_low.inst.cfg
+++ b/resources/quality/Dremel3D40/Dremel_3D40_dremel_pla_0.5kg_low.inst.cfg
@@ -16,7 +16,6 @@ bottom_layers = 4
 cool_fan_enabled = True
 cool_fan_speed = 80
 cool_min_layer_time = 5
-cool_min_speed = 0
 infill_angles = [45,-45]
 infill_before_walls = False
 infill_overlap = 20

--- a/resources/quality/Dremel3D40/Dremel_3D40_dremel_pla_0.5kg_normal.inst.cfg
+++ b/resources/quality/Dremel3D40/Dremel_3D40_dremel_pla_0.5kg_normal.inst.cfg
@@ -17,7 +17,6 @@ cool_fan_enabled = True
 cool_fan_full_at_height = 0.4
 cool_fan_speed = 80
 cool_min_layer_time = 5
-cool_min_speed = 0
 default_material_print_temperature = 220
 infill_angles = [45,-45]
 infill_before_walls = False

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_eco_abs_draft.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_eco_abs_draft.inst.cfg
@@ -16,7 +16,6 @@ bottom_layers = 3
 cool_lift_head = False
 cool_fan_speed = 100
 cool_min_layer_time = 10
-cool_min_speed = 0
 default_material_print_temperature = 205
 infill_before_walls = False
 infill_line_width = 0.4

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_eco_abs_fast.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_eco_abs_fast.inst.cfg
@@ -15,7 +15,6 @@ bottom_layers = 3
 cool_lift_head = False
 cool_fan_speed = 100
 cool_min_layer_time = 10
-cool_min_speed = 0
 default_material_print_temperature = 205
 infill_line_width = 0.56
 infill_overlap = 20

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_eco_abs_high.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_eco_abs_high.inst.cfg
@@ -16,7 +16,6 @@ bottom_layers = 20
 cool_lift_head = False
 cool_fan_speed = 100
 cool_min_layer_time = 10
-cool_min_speed = 0
 default_material_print_temperature = 205
 infill_before_walls = False
 infill_line_width = 0.4

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_eco_abs_low.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_eco_abs_low.inst.cfg
@@ -16,7 +16,6 @@ bottom_layers = 4
 cool_lift_head = False
 cool_fan_speed = 100
 cool_min_layer_time = 10
-cool_min_speed = 0
 default_material_print_temperature = 205
 infill_before_walls = False
 infill_line_width = 0.4

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_eco_abs_normal.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_eco_abs_normal.inst.cfg
@@ -16,7 +16,6 @@ bottom_layers = 10
 cool_lift_head = False
 cool_fan_speed = 100
 cool_min_layer_time = 10
-cool_min_speed = 0
 default_material_print_temperature = 205
 infill_before_walls = False
 infill_line_width = 0.4

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_nylon_draft.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_nylon_draft.inst.cfg
@@ -16,7 +16,6 @@ bottom_layers = 3
 cool_fan_enabled = True
 cool_fan_speed = 50
 cool_min_layer_time = 5
-cool_min_speed = 0
 cool_lift_head = True
 default_material_print_temperature = 240
 infill_before_walls = False

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_nylon_fast.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_nylon_fast.inst.cfg
@@ -15,7 +15,6 @@ bottom_layers = 3
 cool_fan_enabled = True
 cool_fan_speed = 50
 cool_min_layer_time = 5
-cool_min_speed = 0
 cool_lift_head = True
 default_material_print_temperature = 240
 infill_line_width = 0.56

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_nylon_high.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_nylon_high.inst.cfg
@@ -16,7 +16,6 @@ bottom_layers = 20
 cool_fan_enabled = True
 cool_fan_speed = 50
 cool_min_layer_time = 5
-cool_min_speed = 0
 cool_lift_head = True
 default_material_print_temperature = 240
 infill_before_walls = False

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_nylon_low.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_nylon_low.inst.cfg
@@ -16,7 +16,6 @@ bottom_layers = 4
 cool_fan_enabled = True
 cool_fan_speed = 50
 cool_min_layer_time = 5
-cool_min_speed = 0
 cool_lift_head = True
 default_material_print_temperature = 240
 infill_before_walls = False

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_nylon_normal.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_nylon_normal.inst.cfg
@@ -16,7 +16,6 @@ bottom_layers = 10
 cool_fan_enabled = True
 cool_fan_speed = 50
 cool_min_layer_time = 5
-cool_min_speed = 0
 cool_lift_head = True
 default_material_print_temperature = 240
 infill_before_walls = False

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_petg_draft.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_petg_draft.inst.cfg
@@ -17,7 +17,6 @@ cool_fan_enabled = True
 cool_fan_speed = 100
 cool_lift_head = True
 cool_min_layer_time = 10
-cool_min_speed = 0
 default_material_print_temperature = 235
 infill_before_walls = False
 infill_line_width = 0.4

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_petg_fast.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_petg_fast.inst.cfg
@@ -16,7 +16,6 @@ cool_fan_enabled = True
 cool_fan_speed = 100
 cool_lift_head = True
 cool_min_layer_time = 10
-cool_min_speed = 0
 default_material_print_temperature = 235
 infill_line_width = 0.56
 infill_overlap = 20

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_petg_high.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_petg_high.inst.cfg
@@ -20,7 +20,6 @@ cool_fan_enabled = True
 cool_fan_speed = 100
 cool_lift_head = True
 cool_min_layer_time = 10
-cool_min_speed = 0
 default_material_print_temperature = 235
 infill_before_walls = False
 infill_line_width = 0.4

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_petg_low.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_petg_low.inst.cfg
@@ -17,7 +17,6 @@ cool_fan_enabled = True
 cool_fan_speed = 100
 cool_lift_head = True
 cool_min_layer_time = 10
-cool_min_speed = 0
 default_material_print_temperature = 235
 infill_before_walls = False
 infill_line_width = 0.4

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_petg_normal.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_petg_normal.inst.cfg
@@ -17,7 +17,6 @@ cool_fan_enabled = True
 cool_fan_speed = 100
 cool_lift_head = True
 cool_min_layer_time = 10
-cool_min_speed = 0
 default_material_print_temperature = 235
 infill_before_walls = False
 infill_line_width = 0.4

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_draft.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_draft.inst.cfg
@@ -16,7 +16,6 @@ bottom_layers = 3
 cool_fan_enabled = True
 cool_fan_speed = 80
 cool_min_layer_time = 5
-cool_min_speed = 0
 default_material_print_temperature = 230
 infill_angles = [45,-45]
 infill_before_walls = False

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_draft_0.5kg.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_draft_0.5kg.inst.cfg
@@ -16,7 +16,6 @@ bottom_layers = 3
 cool_fan_enabled = True
 cool_fan_speed = 80
 cool_min_layer_time = 5
-cool_min_speed = 0
 infill_angles = [45,-45]
 infill_before_walls = False
 infill_line_width = 0.4

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_fast.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_fast.inst.cfg
@@ -15,7 +15,6 @@ bottom_layers = 3
 cool_fan_enabled = True
 cool_fan_speed = 80
 cool_min_layer_time = 5
-cool_min_speed = 0
 default_material_print_temperature = 240
 infill_line_width = 0.56
 infill_overlap = 20

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_fast_0.5kg.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_fast_0.5kg.inst.cfg
@@ -15,7 +15,6 @@ bottom_layers = 3
 cool_fan_enabled = True
 cool_fan_speed = 80
 cool_min_layer_time = 5
-cool_min_speed = 0
 infill_line_width = 0.56
 infill_overlap = 20
 infill_pattern = zigzag

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_high.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_high.inst.cfg
@@ -16,7 +16,6 @@ bottom_layers = 20
 cool_fan_enabled = True
 cool_fan_speed = 80
 cool_min_layer_time = 5
-cool_min_speed = 0
 default_material_print_temperature = 220
 infill_before_walls = False
 infill_line_width = 0.4

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_high_0.5kg.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_high_0.5kg.inst.cfg
@@ -16,7 +16,6 @@ bottom_layers = 20
 cool_fan_enabled = True
 cool_fan_speed = 80
 cool_min_layer_time = 5
-cool_min_speed = 0
 infill_before_walls = False
 infill_line_width = 0.4
 infill_overlap = 20

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_low.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_low.inst.cfg
@@ -16,7 +16,6 @@ bottom_layers = 4
 cool_fan_enabled = True
 cool_fan_speed = 70
 cool_min_layer_time = 5
-cool_min_speed = 0
 infill_angles = [45,-45]
 infill_before_walls = False
 infill_line_width = 0.4

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_low_0.5kg.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_low_0.5kg.inst.cfg
@@ -16,7 +16,6 @@ bottom_layers = 4
 cool_fan_enabled = True
 cool_fan_speed = 70
 cool_min_layer_time = 5
-cool_min_speed = 0
 infill_angles = [45,-45]
 infill_before_walls = False
 infill_line_width = 0.4

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_normal.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_normal.inst.cfg
@@ -16,7 +16,6 @@ bottom_layers = 10
 cool_fan_enabled = True
 cool_fan_speed = 70
 cool_min_layer_time = 5
-cool_min_speed = 0
 default_material_print_temperature = 230
 infill_angles = [45,-45]
 infill_before_walls = False

--- a/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_normal_0.5kg.inst.cfg
+++ b/resources/quality/Dremel3D45/Dremel_3D45_dremel_pla_normal_0.5kg.inst.cfg
@@ -16,7 +16,6 @@ bottom_layers = 10
 cool_fan_enabled = True
 cool_fan_speed = 70
 cool_min_layer_time = 5
-cool_min_speed = 0
 infill_angles = [45,-45]
 infill_before_walls = False
 infill_line_width = 0.4

--- a/resources/quality/dremel_3d20/Dremel_3D20_dremel_pla_0.5kg_draft.inst.cfg
+++ b/resources/quality/dremel_3d20/Dremel_3D20_dremel_pla_0.5kg_draft.inst.cfg
@@ -17,7 +17,6 @@ cool_fan_enabled = True
 cool_fan_speed = 80
 cool_fan_speed_max = 100
 cool_min_layer_time = 5
-cool_min_speed = 0
 infill_angles = [45,-45]
 infill_before_walls = False
 infill_overlap = 18

--- a/resources/quality/dremel_3d20/Dremel_3D20_dremel_pla_0.5kg_low.inst.cfg
+++ b/resources/quality/dremel_3d20/Dremel_3D20_dremel_pla_0.5kg_low.inst.cfg
@@ -17,7 +17,6 @@ cool_fan_enabled = True
 cool_fan_speed = 70
 cool_fan_speed_max = 100
 cool_min_layer_time = 5
-cool_min_speed = 0
 infill_angles = [45,-45]
 infill_before_walls = False
 infill_overlap = 20

--- a/resources/quality/dremel_3d20/Dremel_3D20_dremel_pla_0.5kg_normal.inst.cfg
+++ b/resources/quality/dremel_3d20/Dremel_3D20_dremel_pla_0.5kg_normal.inst.cfg
@@ -17,7 +17,6 @@ cool_fan_enabled = True
 cool_fan_speed = 70
 cool_fan_speed_max = 100
 cool_min_layer_time = 5
-cool_min_speed = 0
 infill_angles = [45,-45]
 infill_before_walls = False
 infill_overlap = 18


### PR DESCRIPTION
@metalman3797  - this Pull Request onto the develop branch does the following:

1. Fixes issue #102  - removes all quality settings lines that reference cool_min_speed = 0 - this should fix the slicing issue referenced in Issue #102 in Cura version 5.4 for all three printers (3D20, 3D40, 3D45).  A spot check of Cura with this updated version indicates that it uses 10mm/sec as a default minimum speed

![image](https://github.com/metalman3797/Cura-Dremel-Printer-Plugin/assets/19733103/e0b0d34b-e349-4f81-a6d7-4f0657b679ea)


2.  Additionally, this PR updates the version to 0.8.2 - this prepares to release the next version of the plugin